### PR TITLE
Use AjaxError from RxJS

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -1,14 +1,9 @@
 import assert from "assert"
-import { Observable } from "rxjs"
-
-export class AjaxError extends Error {
-  constructor(error) {
-    super(error)
-    this.name = "AjaxError"
-    this.message = `${error.xhr.status}: ${error.xhr.response}`
-    this.xhr = error.xhr
-  }
-}
+import { Observable } from "rxjs/Observable"
+import "rxjs/add/observable/dom/ajax"
+import "rxjs/add/observable/of"
+import "rxjs/add/operator/map"
+import "rxjs/add/operator/catch"
 
 export default opts => {
   assert(opts.url, "You MUST provide an `url`")
@@ -23,8 +18,7 @@ export default opts => {
       body: opts.body,
       headers: {
         Accept: "application/json",
-        "Content-Type": "application/json",
-        credentials: "include"
+        "Content-Type": "application/json"
       }
     })
     .map(request => ({
@@ -33,7 +27,7 @@ export default opts => {
     }))
     .catch(error => Observable.of({
       type: opts.failureType,
-      payload: new AjaxError(error),
+      payload: error,
       error: true
     }))
 }

--- a/test/ajax.test.js
+++ b/test/ajax.test.js
@@ -1,4 +1,4 @@
-import ajax, { AjaxError } from "../src/ajax"
+import ajax from "../src/ajax"
 
 const mockAjax = (status, jsonResponse) =>
   jasmine.Ajax.requests.mostRecent().respondWith({
@@ -23,28 +23,28 @@ describe("ajax()", () => {
 
   describe("Assertions", () => {
     it("should throw if no url is given", () => {
-      let request = createRequestObject()
+      const request = createRequestObject()
       delete request.url
 
       expect(() => ajax(request)).toThrowError()
     })
 
     it("should throw if no method is given", () => {
-      let request = createRequestObject()
+      const request = createRequestObject()
       delete request.method
 
       expect(() => ajax(request)).toThrowError()
     })
 
     it("should throw if no successType is given", () => {
-      let request = createRequestObject()
+      const request = createRequestObject()
       delete request.successType
 
       expect(() => ajax(request)).toThrowError()
     })
 
     it("should throw if no failureType is given", () => {
-      let request = createRequestObject()
+      const request = createRequestObject()
       delete request.failureType
 
       expect(() => ajax(request)).toThrowError()
@@ -84,7 +84,7 @@ describe("ajax()", () => {
 
     it("should have a payload containing an error with a message", done => {
       ajax(createRequestObject()).subscribe(action => {
-        expect(action.payload.message).toEqual("400: \"error from backend\"")
+        expect(action.payload.message).toEqual("ajax error 400")
         done()
       })
 


### PR DESCRIPTION
Just some small possible tweaks that I ran into while checking the source of AjaxObservable for something completely different 

Use native AjaxError instead of re-creating it: https://github.com/ReactiveX/rxjs/blob/master/src/observable/dom/AjaxObservable.ts#L422 
Has xhr, request and status accessible on it. And a random message that is set by RxJS.

And also scale down imports to only what's being used.

@iZettle/web 