### PR TITLE
Add meta to be passed through and allow custom headers

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -11,23 +11,27 @@ export default opts => {
   assert(opts.successType, "You MUST provide a `successType`")
   assert(opts.failureType, "You MUST provide a `failureType`")
 
+  const defaultHeaders = {
+    Accept: "application/json",
+    "Content-Type": "application/json"
+  }
+
   return Observable
     .ajax({
       method: opts.method,
       url: opts.url,
       body: opts.body,
-      headers: {
-        Accept: "application/json",
-        "Content-Type": "application/json"
-      }
+      headers: opts.headers || defaultHeaders
     })
     .map(request => ({
       type: opts.successType,
-      payload: request.response
+      payload: request.response,
+      meta: opts.meta
     }))
     .catch(error => Observable.of({
       type: opts.failureType,
       payload: error,
-      error: true
+      error: true,
+      meta: opts.meta
     }))
 }

--- a/test/ajax.test.js
+++ b/test/ajax.test.js
@@ -6,12 +6,12 @@ const mockAjax = (status, jsonResponse) =>
     responseText: JSON.stringify(jsonResponse)
   })
 
-const createRequestObject = () => ({
+const createRequestObject = opts => (Object.assign({
   method: "GET",
   url: "/foo",
   successType: "SUCCESS",
   failureType: "FAILURE"
-})
+}, opts))
 
 describe("ajax()", () => {
   beforeEach(() => jasmine.Ajax.install())
@@ -51,11 +51,56 @@ describe("ajax()", () => {
     })
   })
 
+  describe("Custom headers", () => {
+    it("should have default headers if no headers were passed in options", done => {
+      const request = createRequestObject()
+
+      const defaultHeaders = {
+        Accept: "application/json",
+        "Content-Type": "application/json"
+      }
+
+      ajax(request).subscribe(() => {
+        const requestHeaders = jasmine.Ajax.requests.mostRecent().requestHeaders
+        expect(requestHeaders).toEqual(
+          Object.assign(defaultHeaders, { "X-Requested-With": "XMLHttpRequest" })
+        )
+        done()
+      })
+
+      mockAjax(200, { foo: "bar" })
+    })
+
+    it("should have custom headers if headers were passed in options", done => {
+      const headers = { foo: "bar" }
+      const request = createRequestObject({ headers })
+
+      ajax(request).subscribe(() => {
+        const requestHeaders = jasmine.Ajax.requests.mostRecent().requestHeaders
+        expect(requestHeaders).toEqual(
+          Object.assign(headers, { "X-Requested-With": "XMLHttpRequest" })
+        )
+        done()
+      })
+
+      mockAjax(200, { foo: "bar" })
+    })
+  })
+
   describe("Successful ajax calls", () => {
     it("should emit the correct action with the response when successful", done => {
       ajax(createRequestObject()).subscribe(action => {
         expect(action.type).toEqual("SUCCESS")
         expect(action.payload).toEqual({ foo: "bar" })
+        done()
+      })
+
+      mockAjax(200, { foo: "bar" })
+    })
+
+    it("should have meta from options", done => {
+      ajax(createRequestObject({ meta: { biz: "buz" } })).subscribe(action => {
+        expect(action.meta).toEqual({ biz: "buz" })
         done()
       })
 
@@ -98,6 +143,15 @@ describe("ajax()", () => {
       })
 
       mockAjax(400, "error from backend")
+    })
+
+    it("should have meta from options", done => {
+      ajax(createRequestObject({ meta: { biz: "buz" } })).subscribe(action => {
+        expect(action.meta).toEqual({ biz: "buz" })
+        done()
+      })
+
+      mockAjax(200, { foo: "bar" })
     })
   })
 })


### PR DESCRIPTION
Why meta? To be able to pass something for tracking or as a reference to that request.

Why headers? To be able to do other types of reqs.
And why not merge with defaults? If you want to omit one of the defaults that would be a tricky.

So if you want to pass custom headers pass them all. Be declarative! :)

@iZettle/web 